### PR TITLE
feat: add item to queue

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -8,6 +8,7 @@ import {
 	PlaySpecificList,
 	PlaySpecificTracks,
 	PreviousSong,
+	QueueItem,
 	SeekPosition,
 	SkipSong,
 	TransferPlayback,
@@ -20,6 +21,7 @@ export enum ActionId {
 	PlaySpecificList = 'playSpecificList',
 	PlaySpecificTracks = 'playSpecificTracks',
 	Pause = 'pause',
+	QueueItem = 'queueItem',
 	VolumeUp = 'volumeUp',
 	VolumeDown = 'volumeDown',
 	VolumeSpecific = 'volumeSpecific',
@@ -345,6 +347,29 @@ export function GetActionsList(executeAction: (fcn: DoAction) => Promise<void>):
 						await TransferPlayback(instance, targetId)
 					}
 				})
+			},
+		},
+		[ActionId.QueueItem]: {
+			name: 'Add Track to Queue',
+			options: [
+				{
+					tooltip: 'Provide the ID for the track',
+					required: true,
+					type: 'textinput',
+					label: 'Track ID',
+					id: 'context_uri',
+					useVariables: true,
+				},
+			],
+			callback: async (action, context) => {
+				if (typeof action.options.context_uri === 'string') {
+					const context_uri_portion = await context.parseVariablesInString(String(action.options.context_uri))
+					const context_uri = `spotify:track:${context_uri_portion}`
+
+					await executeAction(async (instance, deviceId) => {
+						if (deviceId) await QueueItem(instance, deviceId, context_uri)
+					})
+				}
 			},
 		},
 	}

--- a/src/api/playback.ts
+++ b/src/api/playback.ts
@@ -9,6 +9,19 @@ import {
 	BodyParameters,
 } from './util.js'
 
+export async function addItemToQueue(
+	reqOptions: RequestOptionsBase,
+	context_uri: string,
+	options?: DeviceOptions,
+): Promise<Response<void>> {
+	const params: QueryParameters = {
+		uri: context_uri,
+	}
+	if (options && 'deviceId' in options) params.device_id = options.deviceId
+
+	return doPostRequest(reqOptions, '/v1/me/player/queue', params)
+}
+
 export async function getMyCurrentPlaybackState(
 	reqOptions: RequestOptionsBase,
 ): Promise<Response<SpotifyApi.CurrentPlaybackResponse | undefined>> {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,6 @@
 import { getMyDevices, setVolume } from './api/device.js'
 import {
+	addItemToQueue,
 	getMyCurrentPlaybackState,
 	pause,
 	play,
@@ -47,6 +48,27 @@ export async function ChangeVolume(
 		const retry = await instance.checkIfApiErrorShouldRetry(err)
 		if (retry && attempt <= MAX_ATTEMPTS) {
 			return ChangeVolume(instance, deviceId, absolute, volumeOrDelta, attempt + 1)
+		} else {
+			throw err
+		}
+	}
+}
+
+export async function QueueItem(
+	instance: SpotifyInstanceBase,
+	deviceId: string,
+	context_uri: string,
+	attempt = 0,
+): Promise<void> {
+	const reqOptions = instance.getRequestOptionsBase()
+	if (!reqOptions) return
+
+	try {
+		await addItemToQueue(reqOptions, context_uri, { deviceId })
+	} catch (err) {
+		const retry = await instance.checkIfApiErrorShouldRetry(err)
+		if (retry && attempt <= MAX_ATTEMPTS) {
+			return QueueItem(instance, deviceId, context_uri, attempt + 1)
 		} else {
 			throw err
 		}


### PR DESCRIPTION
Adds a feature to add a specific track to queue.

Closes: https://github.com/bitfocus/companion-module-spotify-remote/issues/65