### PR TITLE
Improved error message toString resulting in [Object object] errors.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -236,7 +236,7 @@ class SpotifyInstance extends InstanceBase<DeviceConfig> implements SpotifyInsta
 				await fcn(this, this.config.deviceId || null)
 					.catch((e) => {
 						// console.log(e)
-						this.log('error', `Execute action failed: ${e.toString()}`)
+						this.log('error', `Execute action failed: ${JSON.stringify(e)}`)
 					})
 					.then(() => {
 						// Do a poll asap, to catch the changes


### PR DESCRIPTION
Improved error message toString resulting in [Object object] errors.
Made debugging Spotify error messages a lot easier.
Be careful to not post these logs, cause they might include access tokens.