### PR TITLE
feat: Volume fade, seek controls, and mute actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "spotify-remote",
-	"version": "2.6.0",
+	"version": "2.7.0",
 	"main": "dist/main.js",
 	"type": "module",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -15,11 +15,10 @@
 		"lint-fix": "run lint --fix"
 	},
 	"license": "MIT",
-		"repository": {
+	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/bitfocus/companion-module-spotify-remote.git"
 	},
-
 	"prettier": "@companion-module/tools/.prettierrc.json",
 	"lint-staged": {
 		"*.{css,json,md,scss}": [

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"@companion-module/base": "~1.14.1",
 		"got": "^14.4.7",
 		"p-queue": "^8.1.0",
+		"set-interval-async": "^3.0.3",
 		"type-fest": "^4.39.1"
 	},
 	"devDependencies": {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -38,6 +38,9 @@ export enum ActionId {
 	RepeatState = 'repeatState',
 	ActiveDeviceToConfig = 'activeDeviceToConfig',
 	SwitchActiveDevice = 'switchActiveDevice',
+	Mute = 'mute',
+	Unmute = 'unmute',
+	MuteToggle = 'muteToggle',
 }
 
 export type DoAction = (instance: SpotifyInstanceBase, deviceId: string | null) => Promise<void>
@@ -620,6 +623,47 @@ export function GetActionsList(executeAction: (fcn: DoAction) => Promise<void>):
 						await QueueItem(instance, deviceId, context_uri)
 					})
 				}
+			},
+		},
+		[ActionId.Mute]: {
+			name: 'Mute Volume',
+			description: 'Mute the volume, saving the current volume to restore on unmute',
+			options: [],
+			callback: async () => {
+				await executeActionIfHasDeviceId('mute', async (instance, deviceId) => {
+					const currentVolume = Number(instance.getVariableValue('volume'))
+					instance.premuteVolume = !isNaN(currentVolume) ? currentVolume : instance.premuteVolume
+					instance.setVariableValues({ premuteVolume: instance.premuteVolume })
+					await ChangeVolume(instance, deviceId, true, 0)
+				})
+			},
+		},
+		[ActionId.Unmute]: {
+			name: 'Unmute Volume',
+			description: 'Unmute the volume, restoring the volume to the value before mute',
+			options: [],
+			callback: async () => {
+				await executeActionIfHasDeviceId('unmute', async (instance, deviceId) => {
+					const premuteVolume = instance.premuteVolume
+					await ChangeVolume(instance, deviceId, true, premuteVolume)
+				})
+			},
+		},
+		[ActionId.MuteToggle]: {
+			name: 'Toggle Mute Volume',
+			description: 'Toggle mute/unmute the volume, saving/restoring the current volume',
+			options: [],
+			callback: async () => {
+				await executeActionIfHasDeviceId('mute toggle', async (instance, deviceId) => {
+					const currentVolume = Number(instance.getVariableValue('volume'))
+					instance.setVariableValues({ premuteVolume: instance.premuteVolume })
+					if (!isNaN(currentVolume) && currentVolume > 0) {
+						instance.premuteVolume = currentVolume
+						await ChangeVolume(instance, deviceId, true, 0)
+					} else {
+						await ChangeVolume(instance, deviceId, true, instance.premuteVolume)
+					}
+				})
 			},
 		},
 	}

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -655,9 +655,9 @@ export function GetActionsList(executeAction: (fcn: DoAction) => Promise<void>):
 			callback: async () => {
 				await executeActionIfHasDeviceId('mute toggle', async (instance, deviceId) => {
 					const currentVolume = Number(instance.getVariableValue('volume'))
-					instance.setVariableValues({ premuteVolume: instance.premuteVolume })
 					if (!isNaN(currentVolume) && currentVolume > 0) {
 						instance.premuteVolume = currentVolume
+						instance.setVariableValues({ premuteVolume: instance.premuteVolume })
 						await ChangeVolume(instance, deviceId, true, 0)
 					} else {
 						await ChangeVolume(instance, deviceId, true, instance.premuteVolume)

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -28,6 +28,8 @@ export enum ActionId {
 	VolumeSpecific = 'volumeSpecific',
 	FadeVolume = 'fadeVolume',
 	SeekPosition = 'seekPosition',
+	SeekPositionBack = 'seekPositionBack',
+	SeekPositionForward = 'seekPositionForward',
 	Skip = 'skip',
 	Previous = 'previous',
 	ShuffleToggle = 'shuffleToggle',
@@ -442,12 +444,42 @@ export function GetActionsList(executeAction: (fcn: DoAction) => Promise<void>):
 				})
 			},
 		},
+		[ActionId.SeekPositionBack]: {
+			name: 'Go Backwards X Milliseconds In Currently Playing Track',
+			options: [{ type: 'textinput', label: 'Position (milliseconds)', id: 'position', default: '' }],
+			callback: async (action) => {
+				const positionMs = Number(action.options.position)
+				if (!isNaN(positionMs)) {
+					await executeActionIfHasDeviceId('seek', async (instance, deviceId) => {
+						const currentPositionVariable = instance.getVariableValue('songProgressSeconds')
+						const currentPosition = !isNaN(Number(currentPositionVariable)) ? Number(currentPositionVariable) * 1000 : 0
+						const seekToPosition = Math.max(0, currentPosition - positionMs)
+						await SeekPosition(instance, deviceId, seekToPosition)
+					})
+				}
+			},
+		},
+		[ActionId.SeekPositionForward]: {
+			name: 'Go Forward X Milliseconds In Currently Playing Track',
+			options: [{ type: 'textinput', label: 'Position (milliseconds)', id: 'position', default: '' }],
+			callback: async (action) => {
+				const positionMs = Number(action.options.position)
+				if (!isNaN(positionMs)) {
+					await executeActionIfHasDeviceId('seek', async (instance, deviceId) => {
+						const currentPositionVariable = instance.getVariableValue('songProgressSeconds')
+						const currentPosition = !isNaN(Number(currentPositionVariable)) ? Number(currentPositionVariable) * 1000 : 0
+						const seekToPosition = Math.max(0, currentPosition + positionMs)
+						await SeekPosition(instance, deviceId, seekToPosition)
+					})
+				}
+			},
+		},
 		[ActionId.SeekPosition]: {
 			name: 'Seek To Position In Currently Playing Track',
 			options: [{ type: 'textinput', label: 'Position (milliseconds)', id: 'position', default: '' }],
 			callback: async (action) => {
-				if (typeof action.options.position === 'number') {
-					const positionMs = action.options.position
+				const positionMs = Number(action.options.position)
+				if (!isNaN(positionMs)) {
 					await executeActionIfHasDeviceId('seek', async (instance, deviceId) => {
 						await SeekPosition(instance, deviceId, positionMs)
 					})

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -368,7 +368,7 @@ export function GetActionsList(executeAction: (fcn: DoAction) => Promise<void>):
 					min: 500,
 					max: 300000,
 					step: 500,
-					isVisible: (options) => options.fadeIn === true,
+					isVisible: (options) => options.fadeOut === true,
 				},
 			],
 			callback: async (action) => {
@@ -379,7 +379,6 @@ export function GetActionsList(executeAction: (fcn: DoAction) => Promise<void>):
 						'pause',
 						action.options.fadeOut as boolean,
 						false,
-						0,
 						0,
 						0,
 						Number(action.options.fadeDurationMs),

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -5,6 +5,7 @@ import {
 	ChangeRepeatState,
 	ChangeShuffleState,
 	ChangeVolume,
+	FadeVolume,
 	PlaySpecificList,
 	PlaySpecificTracks,
 	PreviousSong,
@@ -25,6 +26,7 @@ export enum ActionId {
 	VolumeUp = 'volumeUp',
 	VolumeDown = 'volumeDown',
 	VolumeSpecific = 'volumeSpecific',
+	FadeVolume = 'fadeVolume',
 	SeekPosition = 'seekPosition',
 	Skip = 'skip',
 	Previous = 'previous',
@@ -58,19 +60,117 @@ export function GetActionsList(executeAction: (fcn: DoAction) => Promise<void>):
 	const actions: { [id in ActionId]: CompanionActionDefinition | undefined } = {
 		[ActionId.PlayPause]: {
 			name: 'Toggle Play/Pause',
-			options: [],
-			callback: async () => {
+			options: [
+				{
+					type: 'checkbox',
+					label: 'Fade Out Volume on Pause',
+					id: 'fadeOut',
+					default: false,
+				},
+				{
+					type: 'checkbox',
+					label: 'Fade In Volume on Play',
+					id: 'fadeIn',
+					default: false,
+				},
+				{
+					type: 'number',
+					label: 'Start Volume for Fade In',
+					id: 'startVolume',
+					default: 0,
+					min: 0,
+					max: 100,
+					step: 1,
+					isVisible: (options) => options.fadeIn === true,
+				},
+				{
+					type: 'number',
+					label: 'Target Volume for Fade In',
+					id: 'targetVolume',
+					default: 85,
+					min: 0,
+					max: 100,
+					step: 1,
+					isVisible: (options) => options.fadeIn === true,
+				},
+				{
+					type: 'number',
+					label: 'Fade Duration (milliseconds)',
+					id: 'fadeDurationMs',
+					default: 5000,
+					min: 500,
+					max: 300000,
+					step: 500,
+					isVisible: (options) => options.fadeIn === true || options.fadeOut === true,
+				},
+			],
+			callback: async (action) => {
 				await executeActionIfHasDeviceId('play/pause', async (instance, deviceId) => {
-					await ChangePlayState(instance, deviceId, 'toggle')
+					ChangePlayState(
+						instance,
+						deviceId,
+						'toggle',
+						action.options.fadeOut as boolean,
+						action.options.fadeIn as boolean,
+						Number(action.options.startVolume),
+						Number(action.options.targetVolume),
+						Number(action.options.fadeDurationMs),
+					).catch((err) => instance.log('warn', `Play Toggle failed: ${err}`))
 				})
 			},
 		},
 		[ActionId.Play]: {
 			name: 'Play',
-			options: [],
-			callback: async () => {
+			options: [
+				{
+					type: 'checkbox',
+					label: 'Fade In Volume',
+					id: 'fadeIn',
+					default: false,
+				},
+				{
+					type: 'number',
+					label: 'Start Volume',
+					id: 'startVolume',
+					default: 0,
+					min: 0,
+					max: 100,
+					step: 1,
+					isVisible: (options) => options.fadeIn === true,
+				},
+				{
+					type: 'number',
+					label: 'Target Volume',
+					id: 'targetVolume',
+					default: 85,
+					min: 0,
+					max: 100,
+					step: 1,
+					isVisible: (options) => options.fadeIn === true,
+				},
+				{
+					type: 'number',
+					label: 'Fade Duration (milliseconds)',
+					id: 'fadeDurationMs',
+					default: 5000,
+					min: 500,
+					max: 300000,
+					step: 500,
+					isVisible: (options) => options.fadeIn === true,
+				},
+			],
+			callback: async (action) => {
 				await executeActionIfHasDeviceId('play', async (instance, deviceId) => {
-					await ChangePlayState(instance, deviceId, 'play')
+					ChangePlayState(
+						instance,
+						deviceId,
+						'play',
+						false,
+						action.options.fadeIn as boolean,
+						Number(action.options.startVolume),
+						Number(action.options.targetVolume),
+						Number(action.options.fadeDurationMs),
+					).catch((err) => instance.log('warn', `Play failed: ${err}`))
 				})
 			},
 		},
@@ -107,6 +207,42 @@ export function GetActionsList(executeAction: (fcn: DoAction) => Promise<void>):
 						{ id: 'force', label: 'Force Play (from start)' },
 					],
 				},
+				{
+					type: 'checkbox',
+					label: 'Fade In Volume',
+					id: 'fadeIn',
+					default: false,
+				},
+				{
+					type: 'number',
+					label: 'Start Volume',
+					id: 'startVolume',
+					default: 0,
+					min: 0,
+					max: 100,
+					step: 1,
+					isVisible: (options) => options.fadeIn === true,
+				},
+				{
+					type: 'number',
+					label: 'Target Volume',
+					id: 'targetVolume',
+					default: 85,
+					min: 0,
+					max: 100,
+					step: 1,
+					isVisible: (options) => options.fadeIn === true,
+				},
+				{
+					type: 'number',
+					label: 'Fade Duration (milliseconds)',
+					id: 'fadeDurationMs',
+					default: 5000,
+					min: 500,
+					max: 300000,
+					step: 500,
+					isVisible: (options) => options.fadeIn === true,
+				},
 			],
 			callback: async (action, context) => {
 				if (action.options.type && action.options.context_uri && typeof action.options.behavior === 'string') {
@@ -118,7 +254,16 @@ export function GetActionsList(executeAction: (fcn: DoAction) => Promise<void>):
 							? context_uri_portion
 							: `spotify:${action.options.type}:${context_uri_portion}`
 
-						await PlaySpecificList(instance, deviceId, context_uri, behavior)
+						PlaySpecificList(
+							instance,
+							deviceId,
+							context_uri,
+							behavior,
+							action.options.fadeIn as boolean,
+							Number(action.options.startVolume),
+							Number(action.options.targetVolume),
+							Number(action.options.fadeDurationMs),
+						).catch((err) => instance.log('warn', `PlaySpecificList failed: ${err}`))
 					})
 				}
 			},
@@ -142,6 +287,42 @@ export function GetActionsList(executeAction: (fcn: DoAction) => Promise<void>):
 					min: 0,
 					max: 1000000,
 				},
+				{
+					type: 'checkbox',
+					label: 'Fade In Volume',
+					id: 'fadeIn',
+					default: false,
+				},
+				{
+					type: 'number',
+					label: 'Start Volume',
+					id: 'startVolume',
+					default: 0,
+					min: 0,
+					max: 100,
+					step: 1,
+					isVisible: (options) => options.fadeIn === true,
+				},
+				{
+					type: 'number',
+					label: 'Target Volume',
+					id: 'targetVolume',
+					default: 85,
+					min: 0,
+					max: 100,
+					step: 1,
+					isVisible: (options) => options.fadeIn === true,
+				},
+				{
+					type: 'number',
+					label: 'Fade Duration (milliseconds)',
+					id: 'fadeDurationMs',
+					default: 5000,
+					min: 500,
+					max: 300000,
+					step: 500,
+					isVisible: (options) => options.fadeIn === true,
+				},
 			],
 			callback: async (action) => {
 				if (typeof action.options.tracks === 'string') {
@@ -151,17 +332,53 @@ export function GetActionsList(executeAction: (fcn: DoAction) => Promise<void>):
 					})
 
 					await executeActionIfHasDeviceId('start track', async (instance, deviceId) => {
-						await PlaySpecificTracks(instance, deviceId, tracks, Number(action.options.positionMs) || 0)
+						PlaySpecificTracks(
+							instance,
+							deviceId,
+							tracks,
+							Number(action.options.positionMs) || 0,
+							action.options.fadeIn as boolean,
+							Number(action.options.startVolume),
+							Number(action.options.targetVolume),
+							Number(action.options.fadeDurationMs),
+						).catch((err) => instance.log('warn', `PlaySpecificTracks failed: ${err}`))
 					})
 				}
 			},
 		},
 		[ActionId.Pause]: {
 			name: 'Pause Playback',
-			options: [],
-			callback: async () => {
+			options: [
+				{
+					type: 'checkbox',
+					label: 'Fade Out Volume',
+					id: 'fadeOut',
+					default: false,
+				},
+				{
+					type: 'number',
+					label: 'Fade Duration (milliseconds)',
+					id: 'fadeDurationMs',
+					default: 5000,
+					min: 500,
+					max: 300000,
+					step: 500,
+					isVisible: (options) => options.fadeIn === true,
+				},
+			],
+			callback: async (action) => {
 				await executeActionIfHasDeviceId('pause', async (instance, deviceId) => {
-					await ChangePlayState(instance, deviceId, 'pause')
+					ChangePlayState(
+						instance,
+						deviceId,
+						'pause',
+						action.options.fadeOut as boolean,
+						false,
+						0,
+						0,
+						0,
+						Number(action.options.fadeDurationMs),
+					).catch((err) => instance.log('warn', `Pause failed: ${err}`))
 				})
 			},
 		},
@@ -189,6 +406,39 @@ export function GetActionsList(executeAction: (fcn: DoAction) => Promise<void>):
 			callback: async (action) => {
 				await executeActionIfHasDeviceId('volume', async (instance, deviceId) => {
 					await ChangeVolume(instance, deviceId, true, Number(action.options.value))
+				})
+			},
+		},
+		[ActionId.FadeVolume]: {
+			name: 'Fade Volume',
+			options: [
+				{
+					type: 'number',
+					label: 'Target Volume',
+					id: 'targetVolume',
+					default: 50,
+					min: 0,
+					max: 100,
+					step: 1,
+				},
+				{
+					type: 'number',
+					label: 'Fade Duration (milliseconds)',
+					id: 'fadeDurationMs',
+					default: 5000,
+					min: 500,
+					max: 300000,
+					step: 500,
+				},
+			],
+			callback: async (action) => {
+				await executeActionIfHasDeviceId('fade volume', async (instance, deviceId) => {
+					FadeVolume(
+						instance,
+						deviceId,
+						Number(action.options.targetVolume),
+						Number(action.options.fadeDurationMs),
+					).catch((err) => instance.log('warn', `FadeVolume failed: ${err}`))
 				})
 			},
 		},

--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -12,7 +12,7 @@ export async function doGetRequest<T>(reqOptions: RequestOptionsBase, pathname: 
 				Authorization: `Bearer ${reqOptions.accessToken}`,
 				'Content-Type': 'application/json',
 			},
-			responseType: 'json',
+			// responseType: 'json',
 			timeout: {
 				request: DefaultTimeout,
 			},
@@ -36,7 +36,7 @@ export async function doPutRequest(
 				Authorization: `Bearer ${reqOptions.accessToken}`,
 				'Content-Type': 'application/json',
 			},
-			responseType: 'json',
+			// responseType: 'json',
 			timeout: {
 				request: DefaultTimeout,
 			},
@@ -58,7 +58,7 @@ export async function doPostRequest(
 				Authorization: `Bearer ${reqOptions.accessToken}`,
 				'Content-Type': 'application/json',
 			},
-			responseType: 'json',
+			// responseType: 'json',
 			timeout: {
 				request: DefaultTimeout,
 			},

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -11,7 +11,7 @@ export enum FeedbackId {
 }
 
 export function GetFeedbacksList(
-	instance: SpotifyInstanceBase,
+	_instance: SpotifyInstanceBase,
 	getState: () => SpotifyState,
 ): CompanionFeedbackDefinitions {
 	const feedbacks: { [id in FeedbackId]: CompanionFeedbackDefinition | undefined } = {
@@ -111,10 +111,10 @@ export function GetFeedbacksList(
 			},
 			callback: (feedback): boolean => {
 				const currentContext = getState().playbackState?.currentContext
-				instance.log(
-					'debug',
-					`Feedback check for current context. Feedback value: ${feedback.options.id}, Current context: ${JSON.stringify(currentContext)}`,
-				)
+				// instance.log(
+				// 	'debug',
+				// 	`Feedback check for current context. Feedback value: ${feedback.options.id}, Current context: ${JSON.stringify(currentContext)}`,
+				// )
 				return currentContext == feedback.options.id
 			},
 		},

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,4 @@
+import { setIntervalAsync, clearIntervalAsync } from 'set-interval-async/dynamic'
 import { getMyDevices, setVolume } from './api/device.js'
 import {
 	addItemToQueue,
@@ -15,6 +16,26 @@ import { SpotifyInstanceBase } from './types.js'
 
 // Limit the number of retries that we do
 const MAX_ATTEMPTS = 5
+
+export async function GetCurrentVolume(instance: SpotifyInstanceBase, deviceId: string, attempt = 0): Promise<number> {
+	const reqOptions = instance.getRequestOptionsBase()
+	if (!reqOptions) return 0
+
+	try {
+		const data = await getMyDevices(reqOptions)
+		const selectedDevice = data.body?.devices?.find((dev) => dev.id === deviceId)
+		const volume = selectedDevice?.volume_percent ?? 0
+		instance.setVariableValues({ volume: volume })
+		return volume
+	} catch (err) {
+		const retry = await instance.checkIfApiErrorShouldRetry(err)
+		if (retry && attempt <= MAX_ATTEMPTS) {
+			return GetCurrentVolume(instance, deviceId, attempt + 1)
+		} else {
+			throw err
+		}
+	}
+}
 
 export async function ChangeVolume(
 	instance: SpotifyInstanceBase,
@@ -44,6 +65,7 @@ export async function ChangeVolume(
 		if (newVolume > 100) newVolume = 100
 
 		await setVolume(reqOptions, newVolume, { deviceId })
+		await GetCurrentVolume(instance, deviceId)
 	} catch (err) {
 		const retry = await instance.checkIfApiErrorShouldRetry(err)
 		if (retry && attempt <= MAX_ATTEMPTS) {
@@ -128,6 +150,11 @@ export async function ChangePlayState(
 	instance: SpotifyInstanceBase,
 	deviceId: string,
 	action: 'play' | 'pause' | 'toggle',
+	fadeOut = false,
+	fadeIn = false,
+	startVolume = 0,
+	targetVolume = 85,
+	fadeDurationMs = 5000,
 	attempt = 0,
 ): Promise<void> {
 	const reqOptions = instance.getRequestOptionsBase()
@@ -137,14 +164,35 @@ export async function ChangePlayState(
 		const data = await getMyCurrentPlaybackState(reqOptions)
 
 		if ((action === 'pause' || action === 'toggle') && data.body?.is_playing) {
+			if (fadeOut) {
+				await FadeVolume(instance, deviceId, 0, Number(fadeDurationMs))
+			}
 			await pause(reqOptions, { deviceId })
 		} else if ((action === 'play' || action === 'toggle') && !data.body?.is_playing) {
+			if (fadeIn) {
+				await ChangeVolume(instance, deviceId, true, Number(startVolume))
+				await GetCurrentVolume(instance, deviceId)
+			}
 			await play(reqOptions, { deviceId })
+
+			if (fadeIn) {
+				await FadeVolume(instance, deviceId, Number(targetVolume), Number(fadeDurationMs))
+			}
 		}
 	} catch (err) {
 		const retry = await instance.checkIfApiErrorShouldRetry(err)
 		if (retry && attempt <= MAX_ATTEMPTS) {
-			return ChangePlayState(instance, deviceId, action, attempt + 1)
+			return ChangePlayState(
+				instance,
+				deviceId,
+				action,
+				fadeOut,
+				fadeIn,
+				startVolume,
+				targetVolume,
+				fadeDurationMs,
+				attempt + 1,
+			)
 		} else {
 			throw err
 		}
@@ -229,6 +277,10 @@ export async function PlaySpecificList(
 	deviceId: string,
 	context_uri: string,
 	behavior: 'return' | 'resume' | 'force',
+	fadeIn = false,
+	startVolume = 0,
+	targetVolume = 85,
+	fadeDurationMs = 5000,
 	attempt = 0,
 ): Promise<void> {
 	const reqOptions = instance.getRequestOptionsBase()
@@ -241,20 +293,45 @@ export async function PlaySpecificList(
 				if (behavior == 'return' || (behavior == 'resume' && data.body.is_playing)) {
 					instance.log('warn', `Already playing that ${context_uri}`)
 				} else if (behavior == 'resume') {
+					if (fadeIn) {
+						await ChangeVolume(instance, deviceId, true, Number(startVolume))
+						await GetCurrentVolume(instance, deviceId)
+					}
 					await play(reqOptions, { deviceId })
+					if (fadeIn) {
+						await FadeVolume(instance, deviceId, Number(targetVolume), Number(fadeDurationMs))
+					}
 				}
 
 				return
 			}
 		}
+
+		if (fadeIn) {
+			await ChangeVolume(instance, deviceId, true, Number(startVolume))
+			await GetCurrentVolume(instance, deviceId)
+		}
 		await play(reqOptions, {
 			deviceId,
 			context_uri,
 		})
+		if (fadeIn) {
+			await FadeVolume(instance, deviceId, Number(targetVolume), Number(fadeDurationMs))
+		}
 	} catch (err) {
 		const retry = await instance.checkIfApiErrorShouldRetry(err)
 		if (retry && attempt <= MAX_ATTEMPTS) {
-			return PlaySpecificList(instance, deviceId, context_uri, behavior, attempt + 1)
+			return PlaySpecificList(
+				instance,
+				deviceId,
+				context_uri,
+				behavior,
+				fadeIn,
+				startVolume,
+				targetVolume,
+				fadeDurationMs,
+				attempt + 1,
+			)
 		} else {
 			throw err
 		}
@@ -266,23 +343,98 @@ export async function PlaySpecificTracks(
 	deviceId: string,
 	uris: string[],
 	positionMs: number,
+	fadeIn = false,
+	startVolume = 0,
+	targetVolume = 85,
+	fadeDurationMs = 5000,
 	attempt = 0,
 ): Promise<void> {
 	const reqOptions = instance.getRequestOptionsBase()
 	if (!reqOptions) return
 
 	try {
+		if (fadeIn) {
+			await ChangeVolume(instance, deviceId, true, Number(startVolume))
+			await GetCurrentVolume(instance, deviceId)
+		}
+
 		await play(reqOptions, {
 			deviceId: deviceId,
 			uris: uris,
 			position_ms: positionMs,
 		})
+
+		if (fadeIn) {
+			await FadeVolume(instance, deviceId, Number(targetVolume), Number(fadeDurationMs))
+		}
 	} catch (err) {
 		const retry = await instance.checkIfApiErrorShouldRetry(err)
 		if (retry && attempt <= MAX_ATTEMPTS) {
-			return PlaySpecificTracks(instance, deviceId, uris, positionMs, attempt + 1)
+			return PlaySpecificTracks(
+				instance,
+				deviceId,
+				uris,
+				positionMs,
+				fadeIn,
+				startVolume,
+				targetVolume,
+				fadeDurationMs,
+				attempt + 1,
+			)
 		} else {
 			throw err
 		}
 	}
+}
+
+const FADE_MIN_INTERVAL_MS = 500
+
+export async function FadeVolume(
+	instance: SpotifyInstanceBase,
+	deviceId: string,
+	targetVolume: number,
+	fadeDurationMs: number,
+): Promise<void> {
+	const reqOptions = instance.getRequestOptionsBase()
+	if (!reqOptions) return
+
+	const clampedTarget = Math.max(0, Math.min(100, Math.round(targetVolume)))
+	const clampedDuration = Math.max(FADE_MIN_INTERVAL_MS, fadeDurationMs)
+
+	const numSteps = Math.max(1, Math.floor(clampedDuration / FADE_MIN_INTERVAL_MS))
+	const intervalMs = clampedDuration / numSteps
+
+	const startVolume = await GetCurrentVolume(instance, deviceId)
+	if (startVolume === clampedTarget) return
+
+	const signal = instance.startVolumeFade()
+	let step = 0
+
+	await new Promise<void>((resolve) => {
+		const timer = setIntervalAsync(async () => {
+			if (signal.aborted) {
+				await clearIntervalAsync(timer)
+				resolve()
+				return
+			}
+
+			step++
+			const isLast = step >= numSteps
+			const nextVolume = isLast
+				? clampedTarget
+				: Math.max(0, Math.min(100, Math.round(startVolume + ((clampedTarget - startVolume) * step) / numSteps)))
+
+			try {
+				await setVolume(reqOptions, nextVolume, { deviceId })
+				instance.setVariableValues({ volume: nextVolume })
+			} catch (err) {
+				instance.log('warn', `FadeVolume step ${step} failed: ${err}`)
+			}
+
+			if (isLast || signal.aborted) {
+				await clearIntervalAsync(timer)
+				resolve()
+			}
+		}, intervalMs)
+	})
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,8 @@ class SpotifyInstance extends InstanceBase<DeviceConfig> implements SpotifyInsta
 
 	private pollTimer: NodeJS.Timeout | undefined
 
+	private activeVolumeAbort: AbortController | null = null
+
 	private readonly state: SpotifyState
 	private readonly pollQueue = new PQueue({ concurrency: 1 })
 
@@ -98,6 +100,12 @@ class SpotifyInstance extends InstanceBase<DeviceConfig> implements SpotifyInsta
 		} else {
 			return null
 		}
+	}
+
+	public startVolumeFade(): AbortSignal {
+		this.activeVolumeAbort?.abort()
+		this.activeVolumeAbort = new AbortController()
+		return this.activeVolumeAbort.signal
 	}
 
 	async configUpdated(config: DeviceConfig): Promise<void> {
@@ -225,6 +233,11 @@ class SpotifyInstance extends InstanceBase<DeviceConfig> implements SpotifyInsta
 			clearInterval(this.pollTimer)
 			delete this.pollTimer
 		}
+
+		if (this.activeVolumeAbort) {
+			this.activeVolumeAbort.abort()
+			this.activeVolumeAbort = null
+		}
 	}
 	getConfigFields(): SomeCompanionConfigField[] {
 		return GetConfigFields(this.state.playbackState?.deviceInfo?.id)
@@ -236,7 +249,7 @@ class SpotifyInstance extends InstanceBase<DeviceConfig> implements SpotifyInsta
 				await fcn(this, this.config.deviceId || null)
 					.catch((e) => {
 						// console.log(e)
-						this.log('error', `Execute action failed: ${e.toString()}`)
+						this.log('error', `Execute action failed: ${JSON.stringify(e.toString())}`)
 					})
 					.then(() => {
 						// Do a poll asap, to catch the changes

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,6 +51,8 @@ class SpotifyInstance extends InstanceBase<DeviceConfig> implements SpotifyInsta
 		this.config = { ...DEFAULT_CONFIG }
 	}
 
+	premuteVolume: number = 50
+
 	public async checkIfApiErrorShouldRetry(err: any): Promise<boolean> {
 		// Error Code 401 represents out of date token
 		if ('statusCode' in err && err.statusCode == '401') {
@@ -290,6 +292,7 @@ class SpotifyInstance extends InstanceBase<DeviceConfig> implements SpotifyInsta
 			},
 			{ variableId: 'deviceName', name: 'Current device name' },
 			{ variableId: 'deviceId', name: 'Current device id' },
+			{ variableId: 'premuteVolume', name: 'Volume before mute' },
 		]
 
 		this.setVariableDefinitions(variables)
@@ -408,7 +411,6 @@ class SpotifyInstance extends InstanceBase<DeviceConfig> implements SpotifyInsta
 		// Collect updates for batch saving
 		const invalidatedFeedbacks: FeedbackId[] = []
 		const variableUpdates: { [variableId: string]: string | number | boolean | undefined } = {} // TODO - type of this
-
 		if (forceUpdate || oldState?.isPlaying !== newState?.isPlaying) {
 			variableUpdates['isPlaying'] = !!newState?.isPlaying
 			variableUpdates['isPlayingIcon'] = newState?.isPlaying ? '\u23F5' : '\u23F9'

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,8 @@ export interface SpotifyInstanceBase extends InstanceBase<DeviceConfig> {
 
 	startVolumeFade(): AbortSignal
 
+	premuteVolume: number
+
 	// /** Queue a poll for playback status */
 	// queuePoll(): void
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,8 @@ export interface SpotifyInstanceBase extends InstanceBase<DeviceConfig> {
 
 	getRequestOptionsBase(): RequestOptionsBase | null
 
+	startVolumeFade(): AbortSignal
+
 	// /** Queue a poll for playback status */
 	// queuePoll(): void
 }

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -1,6 +1,49 @@
 import { CompanionStaticUpgradeScript, CreateConvertToBooleanFeedbackUpgradeScript } from '@companion-module/base'
 import { DeviceConfig } from './config.js'
 import { FeedbackId } from './feedback.js'
+import { ActionId } from './actions.js'
+
+const FADE_IN_ACTION_IDS = new Set<string>([
+	ActionId.Play,
+	ActionId.PlaySpecificList,
+	ActionId.PlaySpecificTracks,
+	ActionId.Pause,
+	ActionId.PlayPause,
+])
+
+const AddFadeInOptionsUpgradeScript: CompanionStaticUpgradeScript<DeviceConfig> = (_context, props) => {
+	const updatedActions: typeof props.actions = []
+
+	for (const action of props.actions) {
+		if (!FADE_IN_ACTION_IDS.has(action.actionId)) continue
+
+		let changed = false
+		if (!('fadeOut' in action.options)) {
+			action.options['fadeOut'] = false
+			changed = true
+		}
+		if (!('fadeIn' in action.options)) {
+			action.options['fadeIn'] = false
+			changed = true
+		}
+		if (!('startVolume' in action.options)) {
+			action.options['startVolume'] = 0
+			changed = true
+		}
+		if (!('targetVolume' in action.options)) {
+			action.options['targetVolume'] = 85
+			changed = true
+		}
+		if (!('fadeDurationMs' in action.options)) {
+			action.options['fadeDurationMs'] = 5000
+			changed = true
+		}
+
+		if (changed) updatedActions.push(action)
+	}
+
+	return { updatedActions, updatedFeedbacks: [], updatedConfig: null }
+}
 
 export const UpgradeScripts: CompanionStaticUpgradeScript<DeviceConfig>[] = [
 	// Upgrade feedbacks to boolean type
@@ -11,4 +54,5 @@ export const UpgradeScripts: CompanionStaticUpgradeScript<DeviceConfig>[] = [
 		[FeedbackId.ActiveDevice]: true,
 		[FeedbackId.CurrentContext]: true,
 	}),
+	AddFadeInOptionsUpgradeScript,
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2463,6 +2463,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"set-interval-async@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "set-interval-async@npm:3.0.3"
+  checksum: 10c0/7547bb5265648951f3f799391d970f39be16bae2b462ad54b58e96a6a3eb9dda1f183a3b9a4bfdc0a62637b026b494fae74cda075db1c5762b58d0c9172e6d4c
+  languageName: node
+  linkType: hard
+
 "shallow-clone@npm:^3.0.0":
   version: 3.0.1
   resolution: "shallow-clone@npm:3.0.1"
@@ -2547,6 +2554,7 @@ __metadata:
     p-queue: "npm:^8.1.0"
     prettier: "npm:^3.7.4"
     rimraf: "npm:^6.1.2"
+    set-interval-async: "npm:^3.0.3"
     type-fest: "npm:^4.39.1"
     typescript: "npm:~5.9.3"
     typescript-eslint: "npm:^8.51.0"


### PR DESCRIPTION
## Summary

This branch adds several new actions and fixes to the Spotify Remote companion module.

### New Features
- **Volume Fade**: Add volume fade In/Out to Play and Pause actions, plus a standalone `FadeVolume` action
- **Mute controls**: Add `mute`, `unmute`, and `muteToggle` actions
- **Seek controls**: Add `seekPositionBack` and `seekPositionForward` actions

### Bug Fixes
- Fix `seekPosition` action as it never say the position value as a number so it never fired the calls to Spotify
- Fix action errors when Spotify API returns text instead of JSON (API returns both depending on response status).  Many of the Spotify API calls return text when it is a 200 and json when it is not 200 response code.
- Clean up debug log clutter by removing per-feedback log statements
- Fix `package.json` repository field format

fixed #86 
fixed #103 
fixed #51 